### PR TITLE
Added 'main'

### DIFF
--- a/.git-templates/hooks/pre-push
+++ b/.git-templates/hooks/pre-push
@@ -5,7 +5,7 @@
 # Bypass with git push --no-verify
 
 BRANCH=`git rev-parse --abbrev-ref HEAD`
-PROTECTED_BRANCHES="^(master|main)"
+PROTECTED_BRANCHES="^(main|master|dev|release-*|patch-*)"
 
 if [[ "$BRANCH" =~ $PROTECTED_BRANCHES ]]; then
   read -p "Are you sure you want to push to \"$BRANCH\" ? (y/n): " -n 1 -r < /dev/tty


### PR DESCRIPTION
Most git repos in github, and some in the org use `main` as the target branch now a days instead of master.